### PR TITLE
Displacy runs only with latest spacy & thinc versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,10 +15,10 @@ plac==0.9.1
 preshed==0.46.1
 semver==2.2.1
 six==1.10.0
-spacy==0.100.2
+spacy==0.101.0
 sputnik==0.8.2
 text-unidecode==1.0
-thinc==4.2.0
+thinc==5.0.8
 ujson==1.35
 Werkzeug==0.11.4
 wheel==0.24.0


### PR DESCRIPTION
On my machine `python application.py` would return 
`ImportError: No module named linear.avgtron`

until I upgrade to `thinc=5.0.8`

But now hitting `python application.py` returns a different error. It gives :
`RuntimeError: Installed model is not compatible with spaCy version. Please run 'python -m spacy.en.download --force' to install latest compatible model.`

So finally upgrading to `spacy=0.101.0` fixes it and I am able to run the flask server with `python application.py`